### PR TITLE
Support macOS ARM and python 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,58 +76,66 @@ jobs:
         name: distribution-linux-${{ matrix.python_version }}
         path: dist/
 
-#  build-macos-x64:
-#   needs: checkout
-#   runs-on: macOS-14-large
-#   strategy:
-#     matrix:
-#       redis_version:
-#         - "6.2.5"
-#       python_version:
-#         - "3.9"
-#         - "3.11"
-#       include:
-#         - python_version: "3.9"
-#           abi_tag: "cp39-cp39"
-#         - python_version: "3.11"
-#           abi_tag: "cp311-cp311"
-#   steps:
-#     - name: Download checkout
-#       uses: actions/download-artifact@v4
-#       with:
-#         name: checkout
-#         path: .
+ build-macos-x64:
+  needs: checkout
+  # macOS-13 is Intel runner!
+  runs-on: macOS-13
+  strategy:
+    matrix:
+      redis_version:
+        - "6.2.5"
+      python_version:
+        - "3.9"
+      include:
+        - python_version: "3.9"
+          abi_tag: "cp39-cp39"
+  steps:
+    - name: Download checkout
+      uses: actions/download-artifact@v4
+      with:
+        name: checkout
+        path: .
 
-#     - name: Fix +x permission
-#       run: find tools/ -type f -iname "*.sh" -exec chmod +x {} \;
+    - name: Fix +x permission
+      run: find tools/ -type f -iname "*.sh" -exec chmod +x {} \;
 
-#     - name: Setup python
-#       uses: actions/setup-python@v5
-#       with:
-#         python-version: ${{ matrix.python_version }}
+    - name: Setup python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python_version }}
 
-#     - name: Install poetry
-#       run: pipx install poetry
+    - name: List available Xcode versions
+      run: ls /Applications | grep Xcode
 
-#     - name: Build redis
-#       run: tools/build.sh ${{ matrix.redis_version }} redis_wheel/bin
+    - name: Set up Xcode version
+      run: sudo xcode-select -s /Applications/Xcode_14.3.1.app/Contents/Developer      
 
-#     - name: Build distribution
-#       run: |
-#         tools/distrib.sh \
-#           $(pwd) \
-#           ${{ matrix.redis_version }} \
-#           ${{ matrix.abi_tag }} \
-#           macosx_14_0_x86_64
+    - name: Show current version of Xcode
+      run: xcodebuild -version
+  
+    - name: Install poetry
+      run: pipx install poetry
 
-#     - name: Upload distribution
-#       uses: actions/upload-artifact@v4
-#       with:
-#         name: distribution-macos-x64-{{ matrix.python_version }}
-#         path: dist/
+    - name: Build redis
+      run: tools/build.sh ${{ matrix.redis_version }} redis_wheel/bin
+
+    - name: Build distribution
+      run: |
+        tools/distrib.sh \
+          $(pwd) \
+          ${{ matrix.redis_version }} \
+          ${{ matrix.abi_tag }} \
+          macosx_13_0_x86_64
+
+    - name: Upload distribution
+      uses: actions/upload-artifact@v4
+      with:
+        name: distribution-macos-x64-${{ matrix.python_version }}
+        path: dist/
 
  build-macos-arm:
   needs: checkout
+  # macOS-13 is ARM runner!
   runs-on: macOS-14
   strategy:
     matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
   strategy:
     matrix:
       image:
-        - "quay.io/pypa/manylinux2014_x86_64"
+        - "quay.io/pypa/manylinux_2_28_x86_64"
       redis_version:
         - "6.2.5"
       python_version:
@@ -102,7 +102,7 @@ jobs:
 #       run: find tools/ -type f -iname "*.sh" -exec chmod +x {} \;
 
 #     - name: Setup python
-#       uses: actions/setup-python@v4
+#       uses: actions/setup-python@v5
 #       with:
 #         python-version: ${{ matrix.python_version }}
 
@@ -152,10 +152,22 @@ jobs:
       run: find tools/ -type f -iname "*.sh" -exec chmod +x {} \;
 
     - name: Setup python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python_version }}
 
+    - name: List available Xcode versions
+      run: ls /Applications | grep Xcode
+
+    - name: Show current version of Xcode
+      run: xcodebuild -version
+
+    - name: Set up Xcode version
+      run: sudo xcode-select -s /Applications/Xcode_14.3.1.app/Contents/Developer      
+
+    - name: Show current version of Xcode
+      run: xcodebuild -version
+    
     - name: Install poetry
       run: pipx install poetry
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,12 +30,12 @@ jobs:
         - "6.2.5"
       python_version:
         - "3.9"
-#        - "3.11"
+        - "3.11"
       include:
         - python_version: "3.9"
           abi_tag: "cp39-cp39"
-#        - python_version: "3.11"
-#          abi_tag: "cp311-cp311"
+        - python_version: "3.11"
+          abi_tag: "cp311-cp311"
 
   container:
     image: ${{ matrix.image }}
@@ -73,7 +73,7 @@ jobs:
     - name: Upload distribution
       uses: actions/upload-artifact@v4
       with:
-        name: distribution-linux-{{ matrix.python_version }}
+        name: distribution-linux-${{ matrix.python_version }}
         path: dist/
 
 #  build-macos-x64:
@@ -135,12 +135,12 @@ jobs:
         - "6.2.5"
       python_version:
         - "3.9"
-#        - "3.11"
+        - "3.11"
       include:
         - python_version: "3.9"
           abi_tag: "cp39-cp39"
-#        - python_version: "3.11"
-#          abi_tag: "cp311-cp311"
+        - python_version: "3.11"
+          abi_tag: "cp311-cp311"
   steps:
     - name: Download checkout
       uses: actions/download-artifact@v4
@@ -158,9 +158,6 @@ jobs:
 
     - name: List available Xcode versions
       run: ls /Applications | grep Xcode
-
-    - name: Show current version of Xcode
-      run: xcodebuild -version
 
     - name: Set up Xcode version
       run: sudo xcode-select -s /Applications/Xcode_14.3.1.app/Contents/Developer      
@@ -185,5 +182,5 @@ jobs:
     - name: Upload distribution
       uses: actions/upload-artifact@v4
       with:
-        name: distribution-macos-arm-{{ matrix.python_version }}
+        name: distribution-macos-arm-${{ matrix.python_version }}
         path: dist/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,7 +134,7 @@ jobs:
 
  build-macos-arm:
   needs: checkout
-  # macOS-13 is ARM runner!
+  # macOS-14 is ARM runner!
   runs-on: macOS-14
   strategy:
     matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
  push:
   branches:
     - master
+    - paulan/new_builds
  workflow_call:
 
 jobs:
@@ -29,9 +30,12 @@ jobs:
         - "6.2.5"
       python_version:
         - "3.9"
+#        - "3.11"
       include:
         - python_version: "3.9"
           abi_tag: "cp39-cp39"
+#        - python_version: "3.11"
+#          abi_tag: "cp311-cp311"
 
   container:
     image: ${{ matrix.image }}
@@ -72,18 +76,71 @@ jobs:
         name: distribution
         path: dist/
 
- build-macos:
+#  build-macos-x64:
+#   needs: checkout
+#   runs-on: macOS-14-large
+#   strategy:
+#     matrix:
+#       redis_version:
+#         - "6.2.5"
+#       python_version:
+#         - "3.9"
+#         - "3.11"
+#       include:
+#         - python_version: "3.9"
+#           abi_tag: "cp39-cp39"
+#         - python_version: "3.11"
+#           abi_tag: "cp311-cp311"
+#   steps:
+#     - name: Download checkout
+#       uses: actions/download-artifact@v3
+#       with:
+#         name: checkout
+#         path: .
+
+#     - name: Fix +x permission
+#       run: find tools/ -type f -iname "*.sh" -exec chmod +x {} \;
+
+#     - name: Setup python
+#       uses: actions/setup-python@v4
+#       with:
+#         python-version: ${{ matrix.python_version }}
+
+#     - name: Install poetry
+#       run: pipx install poetry
+
+#     - name: Build redis
+#       run: tools/build.sh ${{ matrix.redis_version }} redis_wheel/bin
+
+#     - name: Build distribution
+#       run: |
+#         tools/distrib.sh \
+#           $(pwd) \
+#           ${{ matrix.redis_version }} \
+#           ${{ matrix.abi_tag }} \
+#           macosx_14_0_x86_64
+
+#     - name: Upload distribution
+#       uses: actions/upload-artifact@v3
+#       with:
+#         name: distribution
+#         path: dist/
+
+ build-macos-arm:
   needs: checkout
-  runs-on: macOS-11
+  runs-on: macOS-14
   strategy:
     matrix:
       redis_version:
         - "6.2.5"
       python_version:
         - "3.9"
+#        - "3.11"
       include:
         - python_version: "3.9"
           abi_tag: "cp39-cp39"
+#        - python_version: "3.11"
+#          abi_tag: "cp311-cp311"
   steps:
     - name: Download checkout
       uses: actions/download-artifact@v3
@@ -111,7 +168,7 @@ jobs:
           $(pwd) \
           ${{ matrix.redis_version }} \
           ${{ matrix.abi_tag }} \
-          macosx_11_0_x86_64
+          macosx_14_0_arm64
 
     - name: Upload distribution
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
   steps:
     - uses: actions/checkout@v4
     - name: Upload checkout
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: checkout
         path: .
@@ -41,7 +41,7 @@ jobs:
     image: ${{ matrix.image }}
   steps:
     - name: Download checkout
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: checkout
         path: .
@@ -71,9 +71,9 @@ jobs:
           $(echo ${{ matrix.image }} | awk -F'/' '{print $(NF)}')
 
     - name: Upload distribution
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: distribution
+        name: distribution-linux-{{ matrix.python_version }}
         path: dist/
 
 #  build-macos-x64:
@@ -93,7 +93,7 @@ jobs:
 #           abi_tag: "cp311-cp311"
 #   steps:
 #     - name: Download checkout
-#       uses: actions/download-artifact@v3
+#       uses: actions/download-artifact@v4
 #       with:
 #         name: checkout
 #         path: .
@@ -121,9 +121,9 @@ jobs:
 #           macosx_14_0_x86_64
 
 #     - name: Upload distribution
-#       uses: actions/upload-artifact@v3
+#       uses: actions/upload-artifact@v4
 #       with:
-#         name: distribution
+#         name: distribution-macos-x64-{{ matrix.python_version }}
 #         path: dist/
 
  build-macos-arm:
@@ -143,7 +143,7 @@ jobs:
 #          abi_tag: "cp311-cp311"
   steps:
     - name: Download checkout
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: checkout
         path: .
@@ -171,7 +171,7 @@ jobs:
           macosx_14_0_arm64
 
     - name: Upload distribution
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: distribution
+        name: distribution-macos-arm-{{ matrix.python_version }}
         path: dist/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
  push:
   branches:
     - master
-    - paulan/new_builds
  workflow_call:
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,9 +20,10 @@ jobs:
       id-token: write
     steps:
     - name: Download artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
-        name: distribution
+        pattern: distribution-*
+        merge-multiple: true
         path: dist/
     - name: List artifacts downloaded
       run: ls -R dist

--- a/README.md
+++ b/README.md
@@ -12,12 +12,14 @@ Supported versions of Redis:
 
 Supported platforms:
 
-- `manylinux2014_x86_64`
-- `macosx_11_0_x86_64`
+- `manylinux_2_28_x86_64`
+- `macosx_14_0_x86_64`
+- `macosx_14_0_arm64`
 
 Supported python versions:
 
 - `cp39`
+- `cp311` (except mac x64)
 
 To get the paths of pre-compiled Redis binaries:
 


### PR DESCRIPTION
Update runners and actions to support versions since last update
- macOS-13 for Intel
- macOS-14 for ARM
- update artifact actions, fix breaking changes required by that
- update linux quay so that the node20-based actions run correctly

Set xcode version to 14.3.1 so that we don't target only newer macOS versions.
